### PR TITLE
Token delay

### DIFF
--- a/lib_Partage_BSS/services/BSSConnexionService.py
+++ b/lib_Partage_BSS/services/BSSConnexionService.py
@@ -19,6 +19,7 @@ class BSSConnexion(object):
     :ivar _timestampOfLastToken: Le timestamp auquel on à obtenue notre dernier token. Permet de renouveller le token avant expiration
     :ivar _token: Le token obtenu via l'API pour utiliser les autres méthodes de l'API
     :ivar _url: L'url vers l'API BSS Partage (https://api.partage.renater.fr/service/domain/)
+    :ivar _ttl: le délai d'expiration des tokens reçus (300 secondes par défaut)
     """
     class __BSSConnexion:
 
@@ -44,6 +45,7 @@ class BSSConnexion(object):
             """Le token obtenu via l'API pour utiliser les autres méthodes"""
             self._url = "https://api.partage.renater.fr/service/domain/"
             """L'url vers l'API BSS Partage"""
+            self._ttl = 300
 
         @property
         def url(self):
@@ -78,6 +80,19 @@ class BSSConnexion(object):
                     domain.com
             """
             return self._domain
+
+        @property
+        def ttl(self):
+            """
+            Lecture de la durée de vie des tokens.
+
+            :return: la durée de vie des tokens, en secondes.
+            """
+            return self._ttl
+
+        @ttl.setter
+        def ttl(self, value):
+            self._ttl = value
 
         def setDomainKey(self, listDomainKey):
             """Getter du domaine
@@ -131,7 +146,7 @@ class BSSConnexion(object):
                     if domain not in self._key:
                         raise DomainException(domain + " : Domaine non initialisé")
                     actualTimestamp = round(time())
-                    if (actualTimestamp - self._timestampOfLastToken[domain]) < 270:
+                    if (actualTimestamp - self._timestampOfLastToken[domain]) < int( self._ttl * .9 ):
                         return self._token[domain]
                     else:
                         self._timestampOfLastToken[domain] = actualTimestamp

--- a/test_unitaire/lib_Partage_BSS/services/test_BSSConnexion.py
+++ b/test_unitaire/lib_Partage_BSS/services/test_BSSConnexion.py
@@ -16,6 +16,7 @@ def create_connexion():
     con = BSSConnexion()
     con.setDomainKey({"domain.com": "keyDeTest"})
     con.setDomainKey({"autre.com": "keyDeTest"})
+    con.ttl = 10
     return con
 
 
@@ -95,7 +96,7 @@ def test_getToken_4minApresCreation(mocker):
     with mocker.patch('requests.post', return_value=response):
         token = con.token("domain.com")
         mocker.spy(hmac, 'new')
-        timer.sleep(240)
+        timer.sleep(int( con.ttl * .8 ))
         token = con.token("domain.com")
         assert hmac.new.call_count == 0
     BSSConnexion.instance = None
@@ -108,7 +109,7 @@ def test_getToken_5minApresCreation(mocker):
     with mocker.patch('requests.post', return_value=response):
         token = con.token("domain.com")
         mocker.spy(hmac, 'new')
-        timer.sleep(300)
+        timer.sleep(con.ttl)
         token = con.token("domain.com")
         assert hmac.new.call_count == 1
     BSSConnexion.instance = None


### PR DESCRIPTION
Le TTL des jetons générés par l'API Renater peut être configuré via la propriété ttl de la connexion (cette propriété est initialisée à 300 secondes).

Cela pourrait être utile si le TTL change du côté de Renater et cela permet de ne pas attendre 540 secondes pour l'exécution des tests unitaires.
