### PR TITLE
Méthode alternative de création de compte

### DIFF
--- a/cli-bss.py
+++ b/cli-bss.py
@@ -6,7 +6,7 @@ import argparse, sys
 import pprint
 import json
 
-from lib_Partage_BSS.exceptions import ServiceException, NameException
+from lib_Partage_BSS.exceptions import *
 from lib_Partage_BSS.models.Account import Account, importJsonAccount
 from lib_Partage_BSS.services import AccountService
 from lib_Partage_BSS.models.COS import COS
@@ -19,6 +19,8 @@ epilog = "Exemples d'appel :\n" + \
     "./cli-bss.py --domain=x.fr --domainKey=yourKey --getAccount --email=user@x.fr\n" + \
 	"./cli-bss.py --domain=x.fr --domainKey=yourKey --getAllAccounts --limit=200 --ldapQuery='mail=u*'\n" + \
 	"./cli-bss.py --domain=x.fr --domainKey=yourKey --createAccount --email=user@x.fr --cosId=yourCos --userPassword={SSHA}yourHash\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --createAccountExt " + \
+        "-f name user@x.fr -f zimbraHideInGal oui --userPassword={SSHA}someHash\n" + \
 	"./cli-bss.py --domain=x.fr --domainKey=yourKey --deleteAccount --email=user@x.fr\n" + \
 	"./cli-bss.py --domain=x.fr --domainKey=yourKey --modifyPassword --email=user@x.fr  --userPassword={SSHA}yourHash\n" + \
 	"./cli-bss.py --domain=x.fr --domainKey=yourKey --lockAccount --email=user@x.fr\n" + \
@@ -46,10 +48,16 @@ parser.add_argument('--ldapQuery', metavar='mail=jean*', help="filtre LDAP pour 
 parser.add_argument('--userPassword', metavar='{ssha}HpqRjlh1WEha+6or95YkqA', help="empreinte du mot de passe utilisateur")
 parser.add_argument('--asJson', action='store_const', const=True, help="option pour exporter un compte au format JSON")
 parser.add_argument('--jsonData', metavar='/tmp/myAccount.json', type=argparse.FileType('r'), help="fichier contenant des données JSON")
+parser.add_argument('--field' , '-f' ,
+    action='append' , nargs=2 ,
+    metavar=('name','value') , help="nom et valeur d'un champ du compte")
 
 group = parser.add_argument_group('Opérations implémentées :')
 group.add_argument('--getAccount', action='store_const', const=True, help="rechercher un compte")
 group.add_argument('--createAccount', action='store_const', const=True, help="créer un compte")
+group.add_argument('--createAccountExt',
+    action='store_const', const=True,
+    help="créer un compte en spécifiant les paramètres via -f ou --jsonData")
 group.add_argument('--modifyAccount', action='store_const', const=True, help="mettre à jour un compte")
 group.add_argument('--renameAccount', action='store_const', const=True, help="renommer un compte")
 group.add_argument('--deleteAccount', action='store_const', const=True, help="supprimer un compte")
@@ -157,6 +165,33 @@ elif args['restorePreDeleteAccount'] == True:
         sys.exit(2)
 
     print("Le compte %s a été rétabli" % args['email'])
+
+elif args['createAccountExt'] == True:
+
+    if not args[ 'userPassword' ]:
+        print("Argument '--userPassword' manquant")
+        sys.exit(1)
+
+    # Objet du compte, éventuellement lu depuis un fichier JSON
+    if args['jsonData']:
+        account = importJsonAccount( args[ 'jsonData' ].name )
+    else:
+        account = Account( None )
+
+    if args[ 'field' ]:
+        account.fillAccount({
+                arg[0] : arg[1] for arg in args[ 'field' ]
+            } , allowNameChange = True)
+
+    try:
+        nAccount = AccountService.createAccountExt( account ,
+                args[ 'userPassword' ] )
+    except ( NameException , ServiceException , DomainException ) as err:
+        print("Echec d'exécution : %s" % err)
+        sys.exit(2)
+
+    print( "Le compte %s a été créé" % nAccount.name )
+    print( nAccount.showAttr( ) )
 
 elif args['createAccount'] == True:
 

--- a/lib_Partage_BSS/models/Account.py
+++ b/lib_Partage_BSS/models/Account.py
@@ -412,6 +412,11 @@ class Account(GlobalModel):
     def quota(self, value):
         if isinstance(value, int) or value is None:
             self._quota = value
+        elif isinstance( value , str ):
+            try:
+                self._quota = int( value )
+            except ValueError:
+                raise TypeError
         else:
             raise TypeError
 
@@ -455,6 +460,11 @@ class Account(GlobalModel):
     def used(self, value):
         if isinstance(value, int) or value is None:
             self._used = value
+        elif isinstance( value , str ):
+            try:
+                self._used = int( value )
+            except ValueError:
+                raise TypeError
         else:
             raise TypeError
 
@@ -532,8 +542,13 @@ class Account(GlobalModel):
 
     @zimbraMailQuota.setter
     def zimbraMailQuota(self, value):
-        if isinstance(value, str) or value is None:
+        if isinstance(value, int) or value is None:
             self._zimbraMailQuota = value
+        elif isinstance(value, str):
+            try:
+                self._zimbraMailQuota = int( value )
+            except ValueError:
+                raise TypeError
         else:
             raise TypeError
 

--- a/lib_Partage_BSS/models/Account.py
+++ b/lib_Partage_BSS/models/Account.py
@@ -370,8 +370,10 @@ class Account(GlobalModel):
 
     @mavTransformation.setter
     def mavTransformation(self, value):
-        if isinstance(value, bool) or value is None:
-            self._mavTransformation = value
+        if value is None:
+            self._mavTransformation = None
+        elif utils.checkBoolean( value ):
+            self._mavTransformation = utils.convertToBoolean( value )
         else:
             raise TypeError
 
@@ -465,50 +467,66 @@ class Account(GlobalModel):
 
     @zimbraFeatureBriefcasesEnabled.setter
     def zimbraFeatureBriefcasesEnabled(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraFeatureBriefcasesEnabled = value
+        if value is None:
+            self._zimbraFeatureBriefcasesEnabled = None
+        elif utils.checkBoolean( value ):
+            self._zimbraFeatureBriefcasesEnabled = utils.convertToBoolean(
+                    value )
         else:
             raise TypeError
 
     @zimbraFeatureCalendarEnabled.setter
     def zimbraFeatureCalendarEnabled(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraFeatureCalendarEnabled = value
+        if value is None:
+            self._zimbraFeatureCalendarEnabled = None
+        elif utils.checkBoolean( value ):
+            self._zimbraFeatureCalendarEnabled = utils.convertToBoolean( value )
         else:
             raise TypeError
 
     @zimbraFeatureMailEnabled.setter
     def zimbraFeatureMailEnabled(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraFeatureMailEnabled = value
+        if value is None:
+            self._zimbraFeatureMailEnabled = None
+        elif utils.checkBoolean( value ):
+            self._zimbraFeatureMailEnabled = utils.convertToBoolean( value )
         else:
             raise TypeError
 
     @zimbraFeatureMailForwardingEnabled.setter
     def zimbraFeatureMailForwardingEnabled(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraFeatureMailForwardingEnabled = value
+        if value is None:
+            self._zimbraFeatureMailForwardingEnabled = None
+        elif utils.checkBoolean( value ):
+            self._zimbraFeatureMailForwardingEnabled = utils.convertToBoolean(
+                    value )
         else:
             raise TypeError
 
     @zimbraFeatureOptionsEnabled.setter
     def zimbraFeatureOptionsEnabled(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraFeatureOptionsEnabled = value
+        if value is None:
+            self._zimbraFeatureOptionsEnabled = None
+        elif utils.checkBoolean( value ):
+            self._zimbraFeatureOptionsEnabled = utils.convertToBoolean( value )
         else:
             raise TypeError
 
     @zimbraFeatureTasksEnabled.setter
     def zimbraFeatureTasksEnabled(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraFeatureTasksEnabled = value
+        if value is None:
+            self._zimbraFeatureTasksEnabled = None
+        elif utils.checkBoolean( value ):
+            self._zimbraFeatureTasksEnabled = utils.convertToBoolean( value )
         else:
             raise TypeError
 
     @zimbraHideInGal.setter
     def zimbraHideInGal(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraHideInGal = value
+        if value is None:
+            self._zimbraHideInGal = None
+        elif utils.checkBoolean( value ):
+            self._zimbraHideInGal = utils.convertToBoolean( value )
         else:
             raise TypeError
 
@@ -550,8 +568,10 @@ class Account(GlobalModel):
 
     @zimbraPasswordMustChange.setter
     def zimbraPasswordMustChange(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraPasswordMustChange = value
+        if value is None:
+            self._zimbraPasswordMustChange = None
+        elif utils.checkBoolean( value ):
+            self._zimbraPasswordMustChange = utils.convertToBoolean( value )
         else:
             raise TypeError
 
@@ -573,8 +593,11 @@ class Account(GlobalModel):
 
     @zimbraPrefMailLocalDeliveryDisabled.setter
     def zimbraPrefMailLocalDeliveryDisabled(self, value):
-        if isinstance(value, bool) or value is None:
-            self._zimbraPrefMailLocalDeliveryDisabled = value
+        if value is None:
+            self._zimbraPrefMailLocalDeliveryDisabled = None
+        elif utils.checkBoolean( value ):
+            self._zimbraPrefMailLocalDeliveryDisabled = utils.convertToBoolean(
+                    value )
         else:
             raise TypeError
 

--- a/lib_Partage_BSS/models/Account.py
+++ b/lib_Partage_BSS/models/Account.py
@@ -615,6 +615,37 @@ class Account(GlobalModel):
                     else:
                         propattr.fset(self, listOfAttr[attr])
 
+    def toData(self, checkName = True):
+        """
+        Transforme les données du compte en un dictionnaire pouvant être
+        utilisé avec l'API BSS, après avoir éventuellement vérifié
+        l'adresse.
+
+        :param bool checkName: vérifie l'adresse associée au compte
+
+        :raises NameException: exception levée si le nom n'est pas une \
+        adresse mail valide
+
+        :return: le dictionnaire contenant les informations au sujet du \
+        compte et pouvant être passé à l'API BSS.
+        """
+        if self.name is None:
+            raise NameException( 'Aucune adresse mail spécifiée.' )
+        if checkName and not utils.checkIsMailAddress( self.name ):
+            raise NameException("L'adresse mail " + self.name
+                    + " n'est pas valide")
+        data = {}
+        for attr in self.__dict__:
+            if ( attr == "_zimbraZimletAvailableZimlets"
+                    or self.__getattribute__(attr) is None ):
+                continue
+            attrValue = self.__getattribute__(attr)
+            if isinstance(attrValue, bool):
+                attrValue = utils.changeBooleanToString(attrValue)
+            data[attr[1:]] = attrValue
+        return data
+
+
 def importJsonAccount(jsonAccount):
     json_data = open(jsonAccount)
     data = json.load(json_data)

--- a/lib_Partage_BSS/models/Account.py
+++ b/lib_Partage_BSS/models/Account.py
@@ -631,12 +631,11 @@ class Account(GlobalModel):
             if attr == "name" and not allowNameChange:
                 continue
             propattr = getattr(self.__class__, attr, None)
-            if isinstance(propattr, property):
-                if propattr.fset is not None:
-                    if listOfAttr[attr] == "None":
-                        propattr.fset(self, None)
-                    else:
-                        propattr.fset(self, listOfAttr[attr])
+            if isinstance(propattr, property) and propattr.fset is not None:
+                if listOfAttr[attr] == "None":
+                    propattr.fset(self, None)
+                else:
+                    propattr.fset(self, listOfAttr[attr])
 
     def toData(self, checkName = True):
         """
@@ -677,14 +676,14 @@ def importJsonAccount(jsonAccount):
         raise NameException("Adresse mail non présent dans le fichier json")
     account = Account(data["name"])
     for attr in data:
-        if attr != "name":
-            propattr = getattr(account.__class__, attr, None)
-            if isinstance(propattr, property):
-                if propattr.fset is not None:
-                    if data[attr] == "None":
-                        propattr.fset(account, None)
-                    else:
-                        propattr.fset(account, data[attr])
+        if attr == "name":
+            continue
+        propattr = getattr(account.__class__, attr, None)
+        if isinstance(propattr, property) and propattr.fset is not None:
+            if data[attr] == "None":
+                propattr.fset(account, None)
+            else:
+                propattr.fset(account, data[attr])
     return account
 
 

--- a/lib_Partage_BSS/models/Account.py
+++ b/lib_Partage_BSS/models/Account.py
@@ -601,19 +601,19 @@ class Account(GlobalModel):
         else:
             raise TypeError
 
-    def fillAccount(self, listOfAttr):
+    def fillAccount(self, listOfAttr, allowNameChange=False):
         if not isinstance(listOfAttr, dict) and not isinstance(listOfAttr, list):
             raise TypeError
         for attr in listOfAttr:
-            if attr != "name":
-                propattr = getattr(self.__class__, attr, None)
-                if isinstance(propattr, property):
-                    if propattr.fset is not None:
-                        if listOfAttr[attr] == "None":
-                            propattr.fset(self, None)
-                        else:
-                            propattr.fset(self, listOfAttr[attr])
-
+            if attr == "name" and not allowNameChange:
+                continue
+            propattr = getattr(self.__class__, attr, None)
+            if isinstance(propattr, property):
+                if propattr.fset is not None:
+                    if listOfAttr[attr] == "None":
+                        propattr.fset(self, None)
+                    else:
+                        propattr.fset(self, listOfAttr[attr])
 
 def importJsonAccount(jsonAccount):
     json_data = open(jsonAccount)

--- a/lib_Partage_BSS/services/AccountService.py
+++ b/lib_Partage_BSS/services/AccountService.py
@@ -152,8 +152,6 @@ def createAccountExt(account , password):
             utilisateur
     :param str password: l'empreinte du mot de passe de l'utilisateur
 
-    :return: le compte créé, tel qu'il est vu par l'API
-
     :raises ServiceException: la requête vers l'API a echoué. L'exception \
             contient le code de l'erreur et le message.
     :raises NameException: le nom du compte n'est pas une adresse mail valide, \
@@ -175,8 +173,6 @@ def createAccountExt(account , password):
             'CreateAccount' , data )
     if not utils.checkResponseStatus( response['status'] ):
         raise ServiceException( response['status'], response['message'] )
-
-    return getAccount(account.name)
 
 
 def deleteAccount(name):

--- a/lib_Partage_BSS/services/AccountService.py
+++ b/lib_Partage_BSS/services/AccountService.py
@@ -208,17 +208,7 @@ def modifyAccount(account):
     :raises NameException: Exception levée si le nom n'est pas une adresse mail preSupprimé
     :raises DomainException: Exception levée si le domaine de l'adresse mail n'est pas un domaine valide
     """
-    if not utils.checkIsMailAddress(account.name):
-        raise NameException("L'adresse mail " + account.name + " n'est pas valide")
-    data = {}
-    for attr in account.__dict__:
-        if attr != "_zimbraZimletAvailableZimlets":
-            if account.__getattribute__(attr) is not None:
-                attrValue = account.__getattribute__(attr)
-                if isinstance(attrValue, bool):
-                    attrValue = utils.changeBooleanToString(attrValue)
-                data[attr[1:]] = attrValue
-    response = callMethod(services.extractDomain(account.name), "ModifyAccount", data)
+    response = callMethod(services.extractDomain(account.name), "ModifyAccount", account.toData())
     if not utils.checkResponseStatus(response["status"]):
         raise ServiceException(response["status"], response["message"])
 

--- a/lib_Partage_BSS/services/AccountService.py
+++ b/lib_Partage_BSS/services/AccountService.py
@@ -142,6 +142,43 @@ def createAccount(name,userPassword, cosId, account = None):
     return getAccount(name)
 
 
+def createAccountExt(account , password):
+    """
+    Méthode permettant de créer un compte via l'API BSS en lui passant en
+    paramètre les informations concernant un compte ainsi qu'une empreinte de
+    mot de passe.
+
+    :param Account account: l'objet contenant les informations du compte \
+            utilisateur
+    :param str password: l'empreinte du mot de passe de l'utilisateur
+
+    :return: le compte créé, tel qu'il est vu par l'API
+
+    :raises ServiceException: la requête vers l'API a echoué. L'exception \
+            contient le code de l'erreur et le message.
+    :raises NameException: le nom du compte n'est pas une adresse mail valide, \
+            ou le mot de passe spécifié n'est pas une empreinte.
+    :raises DomainException: le domaine de l'adresse mail n'est pas un domaine \
+            valide.
+    """
+
+    if not re.search(r'^\{\S+\}', password):
+        raise NameException("Le format de l'empreinte du mot de passe "
+            + "n'est pas correcte ; format attendu : {algo}empreinte")
+
+    data = account.toData( )
+    data.update({
+        'password': '',
+        'userPassword': password,
+    })
+    response = callMethod( services.extractDomain( account.name ) ,
+            'CreateAccount' , data )
+    if not utils.checkResponseStatus( response['status'] ):
+        raise ServiceException( response['status'], response['message'] )
+
+    return getAccount(account.name)
+
+
 def deleteAccount(name):
     """
     Permet de supprimer un compte

--- a/lib_Partage_BSS/utils/CheckMethods.py
+++ b/lib_Partage_BSS/utils/CheckMethods.py
@@ -189,3 +189,48 @@ def changeDateToTimestamp(strDate):
         return mktime(datetime.strptime(strDate, '%Y-%m-%d-%H-%M-%S').timetuple())
     else:
         raise TypeError
+
+
+def checkBoolean( v ):
+    """
+    Vérifie si une valeur est un booléen ou peut être convertie en booléen. Il
+    est possible de convertir:
+
+    * les chaînes contenant ``t``, ``true``, ``1``, ``y``, ``yes``, ``on``,
+      ``o``, ``oui``, ``v``, ``vrai``, ``f``, ``false``, ``0``, ``n``, ``no``,
+      ``non``, ``faux`` ou ``off``;
+    * les valeurs numériques;
+    * les instances d'une classe possédant une méthode ``__bool__``
+    """
+    if v is None:
+        return False
+    if isinstance( v , str ):
+        return v.lower( ) in [
+                't' , 'true' , '1' , 'y' , 'yes' , 'on' ,
+                'o', 'oui', 'v', 'vrai' ,
+                'f' , 'false' , 'faux' , '0' , 'n' , 'no' , 'non' , 'off' ]
+    if type( v ) in ( bool , int , long , float ):
+        return True
+    return callable( getattr( v , '__bool__' , None ) )
+
+def convertToBoolean( v ):
+    """
+    Convertit une valeur en booléen.
+
+    Si la valeur à convertir est une chaîne, les valeurs ``true``, ``1``, ``t``,
+    ``y``, ``yes``, ``o``, ``oui``, ``v``, ``vrai`` et ``on`` seront considérées
+    comme vraies.
+
+    Si la valeur à convertir n'est pas une chaîne, la conversion par défaut
+    sera appliquée.
+
+    :param v: la valeur à convertir
+
+    :return: le booléen résultant de la conversion
+    """
+    if isinstance( v , str ):
+        return v.lower( ) in [
+                't' , 'true' , '1' , 'y' , 'yes' , 'on' ,
+                'o', 'oui', 'v', 'vrai' ]
+    return bool( v )
+

--- a/lib_Partage_BSS/utils/CheckMethods.py
+++ b/lib_Partage_BSS/utils/CheckMethods.py
@@ -209,7 +209,7 @@ def checkBoolean( v ):
                 't' , 'true' , '1' , 'y' , 'yes' , 'on' ,
                 'o', 'oui', 'v', 'vrai' ,
                 'f' , 'false' , 'faux' , '0' , 'n' , 'no' , 'non' , 'off' ]
-    if type( v ) in ( bool , int , long , float ):
+    if type( v ) in ( bool , int , float ):
         return True
     return callable( getattr( v , '__bool__' , None ) )
 


### PR DESCRIPTION
Cette série de modifications ajoute, essentiellement, une fonction nommée `createAccountExt` dans le service de gestion des comptes, qui permet la création d'un compte à partir d'une instance de `lib_Partage_BSS.models.Account.Account` et d'une empreinte de mot de passe.

La nouvelle fonction a été interfacée au travers du client en ligne de commande, sous la forme suivante:

    ./cli-bss.py --domain ... --domainKey ... --createAccountExt --userPassword ... \
        -f name 'tutu@example.org' \
        -f zimbraHideInGal 1 \
        -f sn Tutu \
        -f givenName Blah

(Il serait également possible de charger une partie des données depuis un fichier JSON, les arguments spécifiés via "-f truc" ayant priorité)

Par ailleurs, les vérifications de type de la classe représentant les comptes ont été modifiées afin de pouvoir convertir automatiquement les valeus (e.g. si l'on passe une chaîne contenant "12" à une méthode qui devrait accepter un entier). Ces modifications étaient nécessaires pour faire fonctionner `createAccountExt` via la ligne de commande.

Une méthode `toData` a été ajoutée à `Account` afin de mettre en commun la transformation depuis l'instance de représentation vers un dictionnaire de propriétés, et la méthode `fillAccount` a été modifiée afin d'accepter de manière optionelle un paramètre qui lui permet de modifier le nom du compte (ce paramètre est faux par défaut, donc le fonctionnement initial est conservé pour les appels existants).