### PR TITLE
Groupes / listes de distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Les arguments `--domain` et `--domainKey` doivent être fournis pour chaque appe
 Exemples d'appel :
 ```
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --getAccount --email=user@x.fr
-./cli-bss.py --domain=x.fr --domainKey=yourKey --getAccount --email=user@x.fr
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --getAllAccounts --limit=200 --ldapQuery='mail=u*'
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --createAccount --email=user@x.fr --cosId=yourCos --userPassword={SSHA}yourHash
+./cli-bss.py --domain=x.fr --domainKey=yourKey --createAccountExt -f name user@x.fr -f zimbraHideInGal oui --userPassword={SSHA}someHash
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --deleteAccount --email=user@x.fr
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --modifyPassword --email=user@x.fr  --userPassword={SSHA}yourHash
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --lockAccount --email=user@x.fr
@@ -65,6 +65,23 @@ Exemples d'appel :
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --modifyAccountAliases --email=user@x.fr --alias=alias3@x.fr --alias=alias4@x.fr
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --getCos --cosName=etu_s_xx
 ./cli-bss.py --domain=x.fr --domainKey=yourKey --getAllCos
+./cli-bss.py --domain=x.fr --domainKey=yourKey --getAllGroups
+./cli-bss.py --domain=x.fr --domainKey=yourKey --getGroup --email=testgroup1@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --getGroup --email=testgroup1@x.fr --fullData
+./cli-bss.py --domain=x.fr --domainKey=yourKey --getSendAsGroup --email=testgroup1@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey ---createGroup --email=testgroup2@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --createGroupExt -f name testgroup4@x.fr -f displayName 'Groupe 4' -f zimbraMailStatus disabled
+./cli-bss.py --domain=x.fr --domainKey=yourKey --createGroupExt --jsonData=/tmp/data.json
+./cli-bss.py --domain=x.fr --domainKey=yourKey --deleteGroup --email=testgroup6@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --addGroupAlias --email=testgroup4@x.fr --alias=alias@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --removeGroupAlias --email=testgroup4@x.fr --alias=alias@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --setGroupAlias --email=testgroup4@x.fr --alias=alias2@x.fr --alias=alias3@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --addGroupMember --email=testgroup1@x.fr --member=member01@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --removeGroupMember --email=testgroup1@x.fr --member=member01@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --setGroupMember --email=testgroup1@x.fr --member=member01@x.fr --member=member02@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --addGroupSender --email=testgroup1@x.fr --sender=sender03@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --removeGroupSender --email=testgroup1@x.fr --sender=sender03@x.fr
+./cli-bss.py --domain=x.fr --domainKey=yourKey --setGroupSender --email=testgroup1@x.fr --sender=sender03@x.fr  --sender=sender05@x.fr
 ```
 
 ## License

--- a/cli-bss.py
+++ b/cli-bss.py
@@ -35,7 +35,25 @@ epilog = "Exemples d'appel :\n" + \
 	"./cli-bss.py --domain=x.fr --domainKey=yourKey --removeAccountAlias --email=user@x.fr --alias=alias1@x.fr --alias=alias2@x.fr\n" + \
 	"./cli-bss.py --domain=x.fr --domainKey=yourKey --modifyAccountAliases --email=user@x.fr --alias=alias3@x.fr --alias=alias4@x.fr\n" + \
     "./cli-bss.py --domain=x.fr --domainKey=yourKey --getCos --cosName=etu_s_xx\n" + \
-    "./cli-bss.py --domain=x.fr --domainKey=yourKey --getAllCos\n"
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --getAllCos\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --getAllGroups\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --getGroup --email=testgroup1@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --getGroup --email=testgroup1@x.fr --fullData\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --getSendAsGroup --email=testgroup1@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey ---createGroup --email=testgroup2@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --createGroupExt -f name testgroup4@x.fr -f displayName 'Groupe 4' -f zimbraMailStatus disabled\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --createGroupExt --jsonData=/tmp/data.json\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --deleteGroup --email=testgroup6@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --addGroupAlias --email=testgroup4@x.fr --alias=alias@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --removeGroupAlias --email=testgroup4@x.fr --alias=alias@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --setGroupAlias --email=testgroup4@x.fr --alias=alias2@x.fr --alias=alias3@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --addGroupMember --email=testgroup1@x.fr --member=member01@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --removeGroupMember --email=testgroup1@x.fr --member=member01@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --setGroupMember --email=testgroup1@x.fr --member=member01@x.fr --member=member02@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --addGroupSender --email=testgroup1@x.fr --sender=sender03@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --removeGroupSender --email=testgroup1@x.fr --sender=sender03@x.fr\n" + \
+    "./cli-bss.py --domain=x.fr --domainKey=yourKey --setGroupSender --email=testgroup1@x.fr --sender=sender03@x.fr  --sender=sender05@x.fr\n"
+
 parser = argparse.ArgumentParser(description="Client en ligne de commande pour l'API BSS Partage", epilog=epilog, formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument('--domain', required=True, metavar='mondomaine.fr', help="domaine cible sur le serveur Partage")
 parser.add_argument('--domainKey', required=True, metavar="6b7ead4bd425836e8c", help="clé du domaine cible")

--- a/lib_Partage_BSS/models/Group.py
+++ b/lib_Partage_BSS/models/Group.py
@@ -7,21 +7,43 @@ from lib_Partage_BSS.models.GlobalModel import GlobalModel
 
 
 class Group( GlobalModel ):
+    """
+    Classe représentant un groupe ou une liste de distribution dans Partage.
 
+    :ivar _description: description du groupe ou de la liste
+    :ivar _displayName: nom d'affichage du groupe
+    :ivar _zimbraDistributionListSendShareMessageToNewMembers: détermine \
+            si la liste des partages devrait être envoyée par mail aux \
+            nouveaux membres
+    :ivar _zimbraHideInGal: masquer dans la GAL ?
+    :ivar _zimbraMailStatus: ce groupe peut-il recevoir du mail? Si oui, \
+            il s'agit d'une liste de distribution.
+    :ivar _zimbraNotes: notes concernant le groupe ou la liste.
+    :ivar _members: l'ensemble des adresses des membres du groupe ou \
+            de la liste
+    :ivar _senders: l'ensemble des comptes autorisés à envoyer du mail en \
+            utilisant la liste comme adresse d'expédition
+    :ivar _aliases: l'ensemble des alias de la liste
+    """
+
+    # Attributs utilisés dans {Create,Modify}Account
     ATTRIBUTES = (
             'description' , 'displayName' ,
             'zimbraDistributionListSendShareMessageToNewMembers' ,
             'zimbraHideInGal' , 'zimbraMailStatus' , 'zimbraNotes'
         )
 
+    # Attributs synthétiques sous la forme d'ensembles
     SETS = ( 'members' , 'senders' , 'aliases' )
 
-
     def __init__( self , name = None ):
-        if name is not None and not ( isinstance( name , str )
-                and utils.checkIsMailAddress( name ) ):
+        if name is not None and not isinstance( name , str ):
             raise TypeError
+        if name is not None and not utils.checkIsMailAddress( name ):
+            raise NameException( "Adresse mail {} invalide".format( name ) )
+
         GlobalModel.__init__( self , name )
+
         for a in Group.ATTRIBUTES:
             setattr( self , '_{}'.format( a ) , None )
         self._members = set( )
@@ -32,6 +54,16 @@ class Group( GlobalModel ):
 
     @staticmethod
     def _get_set( output , data , name , sub = None ):
+        """
+        Récupère les données correspondant à un attribut de type ensemble depuis
+        la réponse du serveur BSS.
+
+        :param output: l'instance à mettre à jour
+        :param data: les données reçues du serveur
+        :param name: le nom du champ contenant la liste
+        :param sub: le nom des éléments de la liste, s'ils diffèrent du nom \
+                de celle-ci
+        """
         if name not in data: return
         od = data[ name ]
         if sub is None:
@@ -44,6 +76,21 @@ class Group( GlobalModel ):
 
     @staticmethod
     def _from_bool( value , true_value , false_value , xform ):
+        """
+        Vérifie et retourne la valeur à utiliser pour un champ 'booléen' mais
+        encodé sous la forme de chaînes.
+
+        :param value: la nouvelle valeur du champ
+        :param true_value: la chaîne correspondant à une valeur vraie
+        :param false_value: la chaîne correspondant à une valeur fausse
+        :param xform: une fonction qui transforme la chaîne d'entrée si \
+                nécessaire
+
+        :raises TypeError: la valeur n'est ni une chaîne ni un booléen, ou \
+                sa valeur ne correspond pas à l'une des chaînes indiquées
+
+        :return: la nouvelle valeur du champ
+        """
         if value is None:
             return None
         v = None
@@ -60,17 +107,38 @@ class Group( GlobalModel ):
 
     @staticmethod
     def from_bss( data ):
-        try:
-            group = Group( data[ 'name' ] )
-        except TypeError:
-            raise NameException( "L'adresse mail {} n'est pas valide".format(
-                    data[ 'name' ] ) )
+        """
+        Crée une instance en se basant sur des données reçues du serveur
+        Partage, soit via GetGroup soit via GetAllGroups. Dans le premier cas,
+        tous les champs à l'exception de la liste des utilisateurs autorisés à
+        expédier avec l'adresse du groupe seront mis à jour.
+
+        :param data: les données du compte reçues depuis le serveur Partage
+
+        :raises TypeError: un champ n'a pas le format attendu
+
+        :return: l'instance de Group créée, avec ses champs renseignés
+        """
+        group = Group( data[ 'name' ] )
         group.from_dict( data )
         Group._get_set( group._members , data , 'members' , 'member' )
         Group._get_set( group._aliases , data , 'zimbraMailAlias' )
         return group
 
     def from_dict( self , data , allow_name = False ):
+        """
+        Met à jour les champs d'une instance à partir d'un dictionnaire. Seuls
+        les attributs, et optionellement le nom, peuvent être modifiés par cette
+        méthode.
+
+        :param data: le dictionnaire à partir duquel on veut mettre à jour les \
+                données
+        :param allow_name: permettre la modification du champ 'name' à partir \
+                du dictionnaire; si False, une entrée 'name' dans le \
+                dictionnaire sera ignorée
+
+        :raises TypeError: un champ n'a pas le format attendu
+        """
         attrs = (
                 ( 'name' , *Group.ATTRIBUTES ) if allow_name
                 else Group.ATTRIBUTES
@@ -80,11 +148,25 @@ class Group( GlobalModel ):
                 setattr( self , a , data[ a ] )
 
     def senders_from_bss( self , data ):
+        """
+        Remplace la liste des utilisateurs autorisés à expédier avec l'adresse
+        de ce groupe à partir de données fournies par le serveur Partage.
+
+        :param data: les données reçues du serveur Partage
+
+        :return: l'ensemble des adresses autorisées
+        """
         self._senders.clear( )
         Group._get_set( self._senders , data , 'accounts' , 'account' )
         return self.senders
 
     def to_bss( self ):
+        """
+        Génère un dictionnaire pouvant être utilisé pour créer ou modifier un
+        groupe sur le serveur.
+
+        :return: le dictionnaire contenant les attributs
+        """
         rv = { }
         for a in ( 'name' , *Group.ATTRIBUTES ):
             value = getattr( self , a )
@@ -96,6 +178,25 @@ class Group( GlobalModel ):
 
     @staticmethod
     def from_json( source , is_file = False ):
+        """
+        Génère une instance à partir de données au format JSON.
+
+        :param source: la source des données à partir desquelles on doit créer \
+                une instance. Il peut s'agir de source JSON ou bien d'un \
+                fichier, en fonction de la valeur du paramètre is_file. Dans \
+                le second cas, on peut passer aussi bien le chemin du fichier \
+                qu'une instance (par exemple de file) permettant le chargement \
+                du JSON.
+        :param is_file: un booléen qui indique si le paramètre précédent est \
+                un fichier (True) ou du source JSON (False).
+
+        :raises TypeError: si certains des champs ont des types invalides
+        :raises NameException: si l'adresse contenue dans le champ name, ou \
+                l'une des adresses de membres, l'un des alias ou l'une des \
+                entrées d'autorisation sont invalides
+
+        :return: l'instance créée
+        """
         if is_file:
             if isinstance( source , str ):
                 with open( source ) as json_file:
@@ -108,16 +209,43 @@ class Group( GlobalModel ):
 
     @staticmethod
     def from_json_record( record ):
+        """
+        Génère une instance à partir de données JSON décodées dans un
+        dictionnaire Python.
+
+        :param record: le dictionnaire dans lequel les information ont été \
+                décodées
+
+        :raises TypeError: si certains des champs ont des types invalides
+        :raises NameException: si l'adresse contenue dans le champ name, ou \
+                l'une des adresses de membres, l'un des alias ou l'une des \
+                entrées d'autorisation sont invalides
+
+        :return: l'instance créée
+        """
         group = Group( record[ 'name' ] if 'name' in record else None )
         for a in Group.ATTRIBUTES:
             if a in record:
                 setattr( group , a , record[ a ] )
         for s in Group.SETS:
             if s in record:
-                getattr( group , '_{}'.format( s ) ).update( record[ s ] )
+                bad_addr = set([ a for a in record[ s ]
+                                    if not utils.checkIsMailAddress( a ) ])
+                if not bad_addr:
+                    getattr( group , '_{}'.format( s ) ).update( record[ s ] )
+                    continue
+                raise NameException( "Adresse(s) mail {} invalide(s)".format(
+                            ', '.join( bad_addr ) ) )
         return group
 
     def to_json_record( self ):
+        """
+        Génère les données (sous la forme d'un dictionnaire Python) pour un
+        enregistrement JSON décrivant l'instance.
+
+        :return: un dictionnaire contenant les champs appropriés pour \
+                sauvegarde au format JSON
+        """
         rv = {
             a : getattr( self , a )
                 for a in ( 'name' , *Group.ATTRIBUTES )
@@ -134,38 +262,65 @@ class Group( GlobalModel ):
 
     @property
     def members( self ):
+        """
+        La liste des membres, triée par ordre alphabétique.
+        """
         return sorted( self._members )
 
     @property
     def members_set( self ):
+        """
+        L'ensemble des membres, modifiable.
+        """
         return self._members
 
     @property
     def has_members( self ):
+        """
+        La présence, ou non, de membres dans le groupe
+        """
         return bool( self._members )
 
     @property
     def senders( self ):
+        """
+        La liste des expéditeurs autorisés, triée par ordre alphabétique.
+        """
         return sorted( self._senders )
 
     @property
     def senders_set( self ):
+        """
+        L'ensemble des expéditeurs autorisés, modifiable.
+        """
         return self._senders
 
     @property
     def has_senders( self ):
+        """
+        La présence, ou non, d'expéditeurs autorisés
+        """
         return bool( self._senders )
 
     @property
     def aliases( self ):
+        """
+        La liste des alias du groupe, triée par ordre alphabétique.
+        """
         return sorted( self._aliases )
 
     @property
     def aliases_set( self ):
+        """
+        L'ensemble des alias du groupe, modifiable
+        """
         return self._aliases
 
     @property
     def has_aliases( self ):
+        """
+        La présence, ou non, d'alias pour ce groupe
+        """
         return bool( self._aliases )
 
     #---------------------------------------------------------------------------

--- a/lib_Partage_BSS/models/Group.py
+++ b/lib_Partage_BSS/models/Group.py
@@ -1,0 +1,161 @@
+# -*-coding:utf-8 -*
+import json
+
+from lib_Partage_BSS import utils
+from lib_Partage_BSS.exceptions.NameException import NameException
+from lib_Partage_BSS.models.GlobalModel import GlobalModel
+
+
+class Group( GlobalModel ):
+
+    ATTRIBUTES = (
+            'description' , 'displayName' ,
+            'zimbraDistributionListSendShareMessageToNewMembers' ,
+            'zimbraHideInGal' , 'zimbraMailStatus' , 'zimbraNotes'
+        )
+
+    def __init__( self , name = None ):
+        if name is not None and not ( isinstance( name , str )
+                and utils.checkIsMailAddress( name ) ):
+            raise TypeError
+        GlobalModel.__init__( self , name )
+        for a in Group.ATTRIBUTES:
+            setattr( self , '_{}'.format( a ) , None )
+        self._members = set( )
+        self._senders = set( )
+        self._aliases = set( )
+
+    #---------------------------------------------------------------------------
+
+    @staticmethod
+    def _get_set( output , data , name , sub = None ):
+        if name not in data: return
+        od = data[ name ]
+        if sub is None:
+            sub = name
+        if sub in od:
+            if isinstance( od[ sub ] , str ):
+                output.add( od[ sub ] )
+            else:
+                output.update( od[ sub ] )
+
+    @staticmethod
+    def _from_bool( value , true_value , false_value , xform ):
+        if value is None:
+            return None
+        v = None
+        if isinstance( value , str ) and xform( value ) in ( true_value ,
+                    false_value ):
+            v = xform( value )
+        elif isinstance( value , bool ):
+            v = true_value if value else false_value
+        if v is None:
+            raise TypeError
+        return v
+
+    #---------------------------------------------------------------------------
+
+    @staticmethod
+    def from_bss( data ):
+        try:
+            group = Group( data[ 'name' ] )
+        except TypeError:
+            raise NameException( "L'adresse mail {} n'est pas valide".format(
+                    data[ 'name' ] ) )
+        for a in Group.ATTRIBUTES:
+            if a in data:
+                setattr( group , a , data[ a ] )
+        Group._get_set( group._members , data , 'members' , 'member' )
+        Group._get_set( group._aliases , data , 'zimbraMailAlias' )
+        return group
+
+    def senders_from_bss( self , data ):
+        self._senders.clear( )
+        Group._get_set( self._senders , data , 'accounts' , 'account' )
+        return self.senders
+
+    #---------------------------------------------------------------------------
+
+    @property
+    def members( self ):
+        return sorted( self._members )
+
+    @property
+    def senders( self ):
+        return sorted( self._senders )
+
+    @property
+    def aliases( self ):
+        return sorted( self._aliases )
+
+    #---------------------------------------------------------------------------
+
+    @property
+    def description( self ):
+        return self._description
+
+    @description.setter
+    def description( self , value ):
+        if isinstance( value , str ) or value is None:
+            self._description = value
+        else:
+            raise TypeError
+
+    #---------------------------------------------------------------------------
+
+    @property
+    def displayName( self ):
+        return self._displayName
+
+    @displayName.setter
+    def displayName( self , value ):
+        if isinstance( value , str ) or value is None:
+            self._displayName = value
+        else:
+            raise TypeError
+
+    #---------------------------------------------------------------------------
+
+    @property
+    def zimbraDistributionListSendShareMessageToNewMembers( self ):
+        return self._zimbraDistributionListSendShareMessageToNewMembers
+
+    @zimbraDistributionListSendShareMessageToNewMembers.setter
+    def zimbraDistributionListSendShareMessageToNewMembers( self , value ):
+        v = Group._from_bool( value , 'TRUE' , 'FALSE' , lambda x : x.upper( ) )
+        self._zimbraDistributionListSendShareMessageToNewMembers = v
+
+    #---------------------------------------------------------------------------
+
+    @property
+    def zimbraHideInGal( self ):
+        return self._zimbraHideInGal
+
+    @zimbraHideInGal.setter
+    def zimbraHideInGal( self , value ):
+        v = Group._from_bool( value , 'TRUE' , 'FALSE' , lambda x : x.upper( ) )
+        self._zimbraHideInGal = v
+
+    #---------------------------------------------------------------------------
+
+    @property
+    def zimbraMailStatus( self ):
+        return self._zimbraMailStatus == 'enabled'
+
+    @zimbraMailStatus.setter
+    def zimbraMailStatus( self , value ):
+        self._zimbraMailStatus = Group._from_bool( value ,
+                'enabled' , 'disabled' , lambda x : x.lower( ) )
+
+    #---------------------------------------------------------------------------
+
+    @property
+    def zimbraNotes( self ):
+        return self._zimbraNotes
+
+    @zimbraNotes.setter
+    def zimbraNotes( self , value ):
+        if isinstance( value , str ) or value is None:
+            self._zimbraNotes = value
+        else:
+            raise TypeError

--- a/lib_Partage_BSS/services/GroupService.py
+++ b/lib_Partage_BSS/services/GroupService.py
@@ -6,6 +6,10 @@ from lib_Partage_BSS.exceptions import ( NameException , DomainException ,
                                          ServiceException )
 
 
+#-------------------------------------------------------------------------------
+# Opérations d'interrogation
+
+
 def getAllGroups( domain , limit = 100 , offset = 0 ):
     data = {
         'limit'  : limit ,
@@ -64,3 +68,158 @@ def getSendAsGroup( name_or_group ):
     if 'no such distribution list' in response[ 'message' ]:
         return None
     raise ServiceException( response[ 'status' ] , response[ 'message' ] )
+
+
+#-------------------------------------------------------------------------------
+# Création & suppression
+
+def createGroup( name_or_group ):
+    is_group = isinstance( name_or_group , Group )
+    if is_group:
+        if name_or_group.name is None:
+            raise NameException( "L'adresse mail n'est pas renseignée" )
+        data = name_or_group.to_bss( )
+    else:
+        if not isinstance( name_or_group , str ):
+            raise TypeError
+        data = { 'name' : name_or_group }
+
+    if not utils.checkIsMailAddress( data[ 'name' ] ):
+        raise NameException( "L'adresse mail {} n'est pas valide".format( n ) )
+
+    domain = services.extractDomain( data[ 'name' ] )
+    response = callMethod( domain , 'CreateGroup' , data )
+    if not utils.checkResponseStatus( response[ 'status' ] ):
+        raise ServiceException( response[ 'status' ] , response[ 'message' ] )
+
+    if not is_group:
+        return
+    if name_or_group.has_aliases:
+        addGroupAliases( name_or_group.name , name_or_group.aliases )
+    if name_or_group.has_members:
+        addGroupMembers( name_or_group.name , name_or_group.members )
+    if name_or_group.has_senders:
+        addGroupSenders( name_or_group.name , name_or_group.senders )
+
+def deleteGroup( name_or_group ):
+    if isinstance( name_or_group , Group ):
+        if name_or_group.name is None:
+            raise NameException( "L'adresse mail n'est pas renseignée" )
+        data = { 'name' : name_or_group.name }
+    else:
+        if not isinstance( name_or_group , str ):
+            raise TypeError
+        data = { 'name' : name_or_group }
+
+    if not utils.checkIsMailAddress( data[ 'name' ] ):
+        raise NameException( "L'adresse mail {} n'est pas valide".format( n ) )
+
+    domain = services.extractDomain( data[ 'name' ] )
+    response = callMethod( domain , 'DeleteGroup' , data )
+    if not utils.checkResponseStatus( response[ 'status' ] ):
+        raise ServiceException( response[ 'status' ] , response[ 'message' ] )
+
+
+#-------------------------------------------------------------------------------
+# Opération de modification
+
+def modifyGroup( group ):
+    response = callMethod( services.extractDomain( group.name ) ,
+            'ModifyGroup' , group.to_bss( ) )
+    if not utils.checkResponseStatus( response[ 'status' ] ):
+        raise ServiceException( response[ 'status' ] , response[ 'message' ] )
+
+#-------------------------------------------------------------------------------
+
+def _group_set_op( name_or_group , entries , f_name , op_name ):
+    if isinstance( entries , str ):
+        entries = [ entries ]
+    else:
+        entries = list( entries )
+
+    if isinstance( name_or_group , Group ):
+        name = name_or_group.name
+    else:
+        name = name_or_group
+
+    for n in ( name , *entries ):
+        if not utils.checkIsMailAddress( n ):
+            raise NameException(
+                    "L'adresse mail {} n'est pas valide".format( n ) )
+
+    domain = services.extractDomain( name )
+    if '[]' in f_name:
+        entries = [entries]
+
+    for entry in entries:
+        data = {
+                'name' : name ,
+                f_name : entry ,
+            }
+        print( domain , op_name , repr( data ) )
+        response = callMethod( domain , op_name , data )
+        if not utils.checkResponseStatus( response[ 'status' ] ):
+            raise ServiceException( response[ 'status' ] ,
+                    response[ 'message' ] )
+
+def _group_diff_op( name_or_group , new_values , a_name , f_name ,
+            add_op_name , rem_op_name ):
+    if isinstance( name_or_group , Group ):
+        group = name_or_group
+    else:
+        group = getGroup( name_or_group , full_info = 'senders' == a_name )
+
+    if isinstance( new_values , str ):
+        nv_set = set( ( new_values , ) )
+    else:
+        nv_set = set( new_values )
+    grp_set = getattr( group , '{}_set'.format( a_name ) )
+
+    rem = grp_set - nv_set
+    if rem: _group_set_op( group , rem , f_name , rem_op_name )
+
+    add = nv_set - grp_set
+    if add: _group_set_op( group , add , f_name , add_op_name )
+
+
+#-------------------------------------------------------------------------------
+
+def addGroupAliases( name_or_group , aliases ):
+    _group_set_op( name_or_group , aliases ,
+            'alias' , 'AddDistributionListAlias' )
+
+def removeGroupAliases( name_or_group , aliases ):
+    _group_set_op( name_or_group , aliases ,
+            'alias' , 'RemoveDistributionListAlias' )
+
+def updateGroupAliases( name_or_group , new_aliases ):
+    _group_diff_op( name_or_group , new_aliases , 'aliases' , 'alias' ,
+            'AddDistributionListAlias' , 'RemoveDistributionListAlias' )
+
+#-------------------------------------------------------------------------------
+
+def addGroupMembers( name_or_group , members ):
+    _group_set_op( name_or_group , members ,
+            'members[]' , 'AddGroupMembers' )
+
+def removeGroupMembers( name_or_group , members ):
+    _group_set_op( name_or_group , members ,
+            'members[]' , 'RemoveGroupMembers' )
+
+def updateGroupMembers( name_or_group , new_members ):
+    _group_diff_op( name_or_group , new_members , 'members' , 'members[]' ,
+            'AddGroupMembers' , 'RemoveGroupMembers' )
+
+#-------------------------------------------------------------------------------
+
+def addGroupSenders( name_or_group , senders ):
+    _group_set_op( name_or_group , senders ,
+            'account' , 'AddSendAsGroup' )
+
+def removeGroupSenders( name_or_group , senders ):
+    _group_set_op( name_or_group , senders ,
+            'account' , 'DeleteSendAsGroup' )
+
+def updateGroupSenders( name_or_group , new_senders ):
+    _group_diff_op( name_or_group , new_senders , 'senders' , 'account' ,
+            'AddSendAsGroup' , 'DeleteSendAsGroup' )

--- a/lib_Partage_BSS/services/GroupService.py
+++ b/lib_Partage_BSS/services/GroupService.py
@@ -1,0 +1,66 @@
+# -*-coding:utf-8 -*
+from lib_Partage_BSS.models.Group import Group
+from .GlobalService import callMethod
+from lib_Partage_BSS import services , utils
+from lib_Partage_BSS.exceptions import ( NameException , DomainException ,
+                                         ServiceException )
+
+
+def getAllGroups( domain , limit = 100 , offset = 0 ):
+    data = {
+        'limit'  : limit ,
+        'offset' : offset ,
+    }
+
+    response = callMethod( domain , 'GetAllGroups' , data )
+    if not utils.checkResponseStatus( response[ 'status' ] ):
+        raise ServiceException( response[ 'status' ] , response[ 'message' ] )
+
+    if len( response[ 'groups' ] ) <= 1:
+        return []
+
+    groups = response[ 'groups' ][ 'group' ]
+    if isinstance( groups , list ):
+        return [ Group.from_bss( e ) for e in groups ]
+    return Group.from_bss( groups )
+
+
+def getGroup( name , full_info = False ):
+    if not utils.checkIsMailAddress( name ):
+        raise NameException( "L'adresse mail {} n'est pas valide".format(
+                name ) )
+
+    data = { 'name' : name }
+    domain = services.extractDomain( name )
+    response = callMethod( domain , 'GetGroup' , data )
+
+    if utils.checkResponseStatus( response[ 'status' ] ):
+        group = Group.from_bss( response[ 'group' ] )
+        if full_info:
+            getSendAsGroup( group )
+        return group
+    if 'no such distribution list' in response[ 'message' ]:
+        return None
+    raise ServiceException( response[ 'status' ] , response[ 'message' ] )
+
+
+def getSendAsGroup( name_or_group ):
+    if isinstance( name_or_group , Group ):
+        name = name_or_group.name
+        group = name_or_group
+    else:
+        name = name_or_group
+        if not utils.checkIsMailAddress( name ):
+            raise NameException( "L'adresse mail {} n'est pas valide".format(
+                    name ) )
+        group = Group( name )
+
+    data = { 'name' : name }
+    domain = services.extractDomain( name )
+    response = callMethod( domain , 'GetSendAsGroup' , data )
+
+    if utils.checkResponseStatus( response[ 'status' ] ):
+        return group.senders_from_bss( response )
+    if 'no such distribution list' in response[ 'message' ]:
+        return None
+    raise ServiceException( response[ 'status' ] , response[ 'message' ] )

--- a/lib_Partage_BSS/services/GroupService.py
+++ b/lib_Partage_BSS/services/GroupService.py
@@ -310,41 +310,115 @@ def _group_diff_op( name_or_group , new_values , a_name , f_name ,
 #-------------------------------------------------------------------------------
 
 def addGroupAliases( name_or_group , aliases ):
+    """
+    Ajoute des alias à un groupe ou une liste de distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param aliases: un alias sous la forme d'une chaîne, ou une collection \
+            d'alias
+    """
     _group_set_op( name_or_group , aliases ,
             'alias' , 'AddDistributionListAlias' )
 
 def removeGroupAliases( name_or_group , aliases ):
+    """
+    Supprime des alias d'un groupe ou d'une liste de distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param aliases: un alias sous la forme d'une chaîne, ou une collection \
+            d'alias
+    """
     _group_set_op( name_or_group , aliases ,
             'alias' , 'RemoveDistributionListAlias' )
 
 def updateGroupAliases( name_or_group , new_aliases ):
+    """
+    Met à jour les alias d'un groupe ou d'une liste de distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param aliases: un alias sous la forme d'une chaîne, ou une collection \
+            d'alias
+    """
     _group_diff_op( name_or_group , new_aliases , 'aliases' , 'alias' ,
             'AddDistributionListAlias' , 'RemoveDistributionListAlias' )
 
 #-------------------------------------------------------------------------------
 
 def addGroupMembers( name_or_group , members ):
+    """
+    Ajoute des membres à un groupe ou une liste de distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param members: un membre sous la forme d'une chaîne, ou une collection \
+            de membres
+    """
     _group_set_op( name_or_group , members ,
             'members[]' , 'AddGroupMembers' )
 
 def removeGroupMembers( name_or_group , members ):
+    """
+    Supprime des membres d'un groupe ou d'une liste de distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param members: un membre sous la forme d'une chaîne, ou une collection \
+            de membres
+    """
     _group_set_op( name_or_group , members ,
             'members[]' , 'RemoveGroupMembers' )
 
 def updateGroupMembers( name_or_group , new_members ):
+    """
+    Met à jour les membres d'un groupe ou d'une liste de distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param members: un membre sous la forme d'une chaîne, ou une collection \
+            de membres
+    """
     _group_diff_op( name_or_group , new_members , 'members' , 'members[]' ,
             'AddGroupMembers' , 'RemoveGroupMembers' )
 
 #-------------------------------------------------------------------------------
 
 def addGroupSenders( name_or_group , senders ):
+    """
+    Ajoute des utilisateurs autorisés à un groupe ou une liste de distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param members: un utilisateur autorisé sous la forme d'une chaîne, ou une \
+            collection d'utilisateurs autorisés
+    """
     _group_set_op( name_or_group , senders ,
             'account' , 'AddSendAsGroup' )
 
 def removeGroupSenders( name_or_group , senders ):
+    """
+    Supprime des utilisateurs autorisés d'un groupe ou d'une liste de
+    distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param members: un utilisateur autorisé sous la forme d'une chaîne, ou une \
+            collection d'utilisateurs autorisés
+    """
     _group_set_op( name_or_group , senders ,
             'account' , 'DeleteSendAsGroup' )
 
 def updateGroupSenders( name_or_group , new_senders ):
+    """
+    Met à jour les utilisateurs autorisés d'un groupe ou d'une liste de
+    distribution.
+
+    :param name_or_group: le nom du groupe, ou l'instance de modèle \
+            correspondante
+    :param members: un utilisateur autorisé sous la forme d'une chaîne, ou une \
+            collection d'utilisateurs autorisés
+    """
     _group_diff_op( name_or_group , new_senders , 'senders' , 'account' ,
             'AddSendAsGroup' , 'DeleteSendAsGroup' )

--- a/lib_Partage_BSS/services/GroupService.py
+++ b/lib_Partage_BSS/services/GroupService.py
@@ -36,13 +36,16 @@ def getAllGroups( domain , limit = 100 , offset = 0 ):
     if not utils.checkResponseStatus( response[ 'status' ] ):
         raise ServiceException( response[ 'status' ] , response[ 'message' ] )
 
-    if len( response[ 'groups' ] ) <= 1:
+    # Attention : xmljson retourne un dictionnaire contenant une entrée également par attribut XML
+    # Donc il y a une entrée pour l'attribut "type" de "<groups type="array">"
+    if len( response[ 'groups' ] ) == 1:
         return []
 
     groups = response[ 'groups' ][ 'group' ]
     if isinstance( groups , list ):
         return [ Group.from_bss( e ) for e in groups ]
-    return Group.from_bss( groups )
+    else:
+        return [ Group.from_bss(groups) ]
 
 
 def getGroup( name , full_info = False ):


### PR DESCRIPTION
Cette branche implémente le support des groupes / listes de distribution de manière similaire à ce qui existe déjà pour les comptes.

L'implémentation est composée:

* d'une classe de modèle, `models.Group.Group`
* d'un module implémentant le service, `services.GroupService`; il permet l'ajout, la suppression, la modification des groupes, les requêtes d'interrogation correspondantes, ainsi que les fonctions permettant de manipuler les alias, les listes de membres et les utilisateurs autorisés à utiliser le groupe comme adresse d'expédition;
* d'une série de paramètres supplémentaires pour `cli-bss.py`.